### PR TITLE
Fix the heading outline and use the right elements for captions and nav

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,261 @@
+# Frontend audit
+
+Full read of all six HTML pages, seven CSS files and `js/main.js` (~2,800 lines).
+Stage 1 is already committed. Everything below it is proposed, not done.
+
+Totals as they stand: **35 KB CSS**, **21 KB JS**, **56 distinct classes**, 37 sprite
+icons, two variable fonts from Google.
+
+---
+
+## What is already good
+
+Worth saying, because it shapes what is worth changing. The tokens are genuinely
+complete and consistently used — nine unused ones out of ~60 is a very low miss rate.
+Every image has `width`/`height`, so nothing shifts as the page loads. `role="list"` is
+correctly applied everywhere `list-style: none` would otherwise strip list semantics in
+Safari. Reduced-motion is handled in five places rather than forgotten. The video
+loading strategy (fetch near the viewport, play only on screen, respect Data Saver) is
+better than most production sites manage. The comments explain *why*, not *what*.
+
+The problems below are refinements on something already well built.
+
+---
+
+## Stage 1 — semantics (committed: `a9a8137`)
+
+### Heading levels
+
+You asked specifically about h1 → h3 jumps. **There was exactly one, on the homepage.**
+The four project cards were `h3` with no `h2` anywhere above them. Now `h2`.
+
+The five case studies had **no jumps at all**. They already read
+h1 → h2 (kicker) → h3 (heading) → h4 (steps), which is a correct, non-skipping outline.
+Your instinct that the kicker sits a level above the heading is exactly what the markup
+already encodes, so nothing there needed relabelling.
+
+What the case studies *do* have is an inconsistent mapping between level and style:
+
+| Page | h2 style | h3 style |
+|---|---|---|
+| pocus, medication, nikita | `text-subtitle text-subtle` | `text-title` |
+| nga | `text-subtitle text-subtle` | `text-subtitle text-stronger` |
+| rat | `text-title` (real heading, not a kicker) | `text-subtitle text-subtle` |
+
+So `rat.html` inverts the convention and `nga.html` introduces a third variant. A reader
+moving between case studies gets a different visual hierarchy on each. See Stage 2.
+
+### Elements
+
+- **20 captioned images** were `<div>` + `<img>` + `<p>` → now `<figure>` + `<figcaption>`.
+  This is the single clearest "styled div" in the codebase: an image with a caption is
+  the textbook `figure` case.
+- **The previous/next block** at the foot of each case study was a bare `<div>` → now
+  `<nav aria-label="Case studies">`. It is site navigation and was invisible in the
+  landmark list.
+- `aria-labelledby="projects-heading"` pointed at an id that does not exist → replaced
+  with `aria-label="Projects"`, so the landmark has a name again.
+- Redundant `class="text-display"` on two spans inside an h1 that already carries it.
+- **Copy-email status region bug**: `main.js` announces "Email copied" through
+  `[data-copy-status]`, which only existed on the homepage. The five case studies had
+  `aria-live="polite"` on the button instead — the exact approach the comment in
+  `main.js` says is unreliable. The region now exists on all six pages; the `aria-live`
+  attributes are gone.
+- Two empty `<section>` elements in `nikita.html` rendering as blank padded space.
+
+---
+
+## Stage 2 — CSS (proposed)
+
+### Dead code, delete outright
+
+Verified by diffing every selector against every HTML file and against `main.js`:
+
+| What | Where | Note |
+|---|---|---|
+| `.elevation-01/02/03` | `layout.css` | Never used on any element |
+| `.tag` | `home.css`, `typography.css` | Component with no markup |
+| `.text-large-body` | `typography.css` | Never used |
+| `.text-strongest` | `typography.css` | Never used |
+| `.projects-heading` | `home.css` | Left behind when the heading was removed |
+| `.button--dock-end` | `components.css` + `main.js` | A whole cursor variant, never applied |
+| 9 unused tokens | `tokens.css` | `--colour-grey-60`, `--colour-transparent`, `--colour-stroke-1`, `--colour-image-placeholder`, `--fs-xxs`, `--fw-light`, `--spacing-big-s`, `--page-max-width-small`, `--radius-none` |
+| `#icon-eye` | `sprite.svg` | Only sprite symbol never referenced |
+
+That is roughly **40 lines of CSS and 25 lines of JS gone with zero behaviour change**.
+Keep the unused tokens if you want the scale to stay complete as a design system — that
+is a defensible reason, unlike the dead classes.
+
+### The 87 `class="text-body"` problem
+
+This is the biggest class-count reduction available, and it needs a decision from you
+because it contradicts a rule in `CLAUDE.md`.
+
+`class="text-body"` appears **87 times**, on 103 `<p>` and 4 `<li>` — and *nowhere else*.
+`text-caption text-subtle` appears 20 times, all on captions. `text-subtitle text-subtle`
+29 times. Combined, roughly **130 class attributes that carry no information**: they say
+"this paragraph looks like a paragraph".
+
+The rule "never style raw elements directly" is a good default, and it earns its keep for
+headings, where the level and the size genuinely need to vary independently. It does not
+earn its keep for body copy that is identical in all 107 places. Three scoped rules —
+
+```css
+.project-section p,
+.project-section li { /* what .text-body does */ }
+.project-section figcaption { /* what .text-caption text-subtle does */ }
+```
+
+— would remove ~130 class attributes from the markup and shrink every HTML file
+noticeably. The type classes stay available for the cases that deviate.
+
+**Trade-off, stated honestly:** you lose the ability to see the type ramp in the markup at
+a glance, and a `<p>` dropped outside `.project-section` no longer inherits anything. If
+you value reading the hierarchy straight off the HTML, keep it as is — that is a real
+benefit, not a rationalisation. My read is that at 87 identical repetitions the ratio has
+tipped, but it is your codebase and your call. **If you take this, update `CLAUDE.md` in
+the same commit** so the rule and the code do not disagree.
+
+### Structural duplication
+
+Seven classes exist only to say "stack these children in a column with a gap":
+`.projects-heading`, `.project-card__body`, `.project-hero__title`, `.project-hero__detail`,
+`.project-section__image`, `.footer__links`, `.footer__text`. A single utility —
+
+```css
+.stack { display: flex; flex-direction: column; gap: var(--stack-gap, var(--spacing-m)); }
+```
+
+— replaces all seven, with `style="--stack-gap: var(--spacing-xs)"` where the gap differs.
+Seven named classes become one. The cost is that gap values move into the markup, which
+is arguably worse for a design system than for a website. **My recommendation: do the
+deletions and the `text-body` change first, live with them, and only reach for `.stack` if
+the CSS still feels repetitive afterwards.** Two of those seven are already gone by then.
+
+### Smaller CSS items
+
+- **`body { overflow-x: hidden }` in `layout.css` is a likely cause of your open
+  TODO bug** "the footer doesn't reveal like it used to, on mobile". Overflow on `body`
+  makes it a scroll container, which is a well-known way to break `position: sticky` on
+  descendants — and `.footer` is sticky. Worth testing first: remove it, then find
+  whatever is actually overflowing sideways and fix that directly.
+- `.navbar__logo:hover` (`components.css:304`) and `.text-link:hover`
+  (`typography.css:90`) sit **outside** `@media (hover: hover)`, which the comment block
+  in `tokens.css` says everything must do. On a phone, tapping the logo leaves it stuck
+  brand-red until you tap elsewhere. Your own rule, two rules missing it.
+- **`section { padding: … }` styles a raw element**, then `.project-section` immediately
+  resets it to `0`. The base rule is being fought rather than used. Scope it to a class.
+- **`#home-hero` and `#footer-cycling-icon` are ID selectors used for styling.** Both
+  should be classes; ids are for anchors and scripting. `#footer-cycling-icon` also
+  hardcodes `padding-bottom: 3px`, the only hardcoded value in the codebase.
+- `.button--disabled` duplicates what `:disabled` already provides, and the markup
+  carries both. Use `.button:disabled` and delete the class.
+- **`.has-custom-cursor` rules live in `reset.css`.** A reset should not know a component
+  exists. Move to `components.css`.
+- **Five separate `@media (prefers-reduced-motion: reduce)` blocks** across four files.
+  Correct behaviour, scattered enforcement — easy to forget the sixth.
+
+### Loading
+
+Seven render-blocking stylesheets per page (six local + Google Fonts). The local six are
+cheap on HTTP/2 but not free. More significant: **`Figtree:ital,wght@0,300..900;1,300..900`
+requests the italic axis, and there is not a single `<em>` or `<i>` on the entire site.**
+Dropping `ital` removes a whole font file from every page load. Both families also request
+weights 200–900 when only 400/500/600/700 are used.
+
+The bigger win, if you want it, is self-hosting both fonts subset to Latin: it removes two
+DNS lookups, two TLS handshakes and a render-blocking third-party round trip from every
+page. That is a real chunk of your time-to-first-paint, and it is the single most
+effective "make it lightweight" change available.
+
+---
+
+## Stage 3 — JavaScript (proposed)
+
+`main.js` is 523 lines. Roughly 40% is the custom cursor. You have chosen to keep both
+the cursor and the footer cycler and slim them, which is the right instinct for a design
+portfolio — they are the personality, and personality is the product here.
+
+### Custom cursor (~150 lines JS, ~90 CSS)
+
+- Delete the `button--dock-end` branch entirely: dead in CSS, dead in markup, and it
+  costs a `classList.contains` on every dock plus a second measurement path.
+- The `measuring-dock-target` forced-reflow dance is clever and correct, but it exists
+  only because the navbar is `justify-content: space-between`, so opening the dock slot
+  shifts siblings. A fixed-width or `margin-left: auto` navbar would remove the need for
+  the whole measurement mechanism.
+- `sessionStorage` is written on **every** `mousemove`. That is hundreds of writes a
+  second during normal movement, and `sessionStorage` is synchronous and hits disk.
+  Throttle to the `mouseleave`/`pagehide` event instead — one write, same result.
+- **Accessibility note, not a request to remove it:** `cursor: none` on every link and
+  button means anyone with a motor or vision difficulty who relies on the system cursor
+  (including a larger or high-contrast OS cursor) loses it. The dot is 24px and
+  brand-red, so it is visible — but it does not respect OS cursor settings. Consider
+  disabling it under `prefers-reduced-motion: reduce`, which is a reasonable proxy.
+
+### Footer icon cycler (~45 lines)
+
+- `setInterval` at 300ms **runs forever**, including while the tab is in the background.
+  Gate it on `document.visibilityState` — a two-line change that stops it burning battery
+  on a tab nobody is looking at.
+- 30 of the 37 sprite icons exist solely to feed this loop. That is fine if you like it
+  (I think you do), but it means the 27 KB sprite is essentially a decorative asset. Worth
+  knowing what it is buying.
+
+### Navbar (~70 lines)
+
+- `sectionLinkMap` and `sectionIds` are built with 10 lines of DOM walking, and the only
+  thing either is ever used for is `const isHomepage = sectionIds.length > 0`. Replace the
+  whole block with a `data-page="home"` attribute on `<body>`, or a single
+  `document.getElementById('projects')` check.
+- The nav-link handler **delays every navigation by 240ms** via
+  `setTimeout(() => window.location.href = href, 240)` after `preventDefault()`. This adds
+  a quarter-second to every click, and hand-rolling navigation loses the browser's own
+  handling. If the delay exists to let the bar animate, that animation is not worth 240ms
+  on every page change. My recommendation is to remove it.
+- `navLinks.forEach` runs before `suppressHide` and `suppressTimeout` are declared further
+  down the file. It works — `let` hoists into the temporal dead zone but the handler only
+  runs on click, long after declaration — but it reads as a bug and will trip up the next
+  person, including you in six months.
+
+---
+
+## Stage 4 — content and site integrity
+
+Not code quality, but found while reading and worth acting on before anything else here.
+
+- **`nga.html` and `nikita.html` are live, published and unreachable.** No homepage card
+  links to either. `rat.html`'s footer has no "next", so the previous/next chain dead-ends
+  before them. They are reachable only by direct URL — and by search engines, which will
+  index them. `nga.html` ships **five `placeholder.svg` images** with captions describing
+  what should be there; `nikita.html` has a placeholder hero and one section of copy.
+  Either finish them, or add `<meta name="robots" content="noindex">` until you do.
+- `card-nga.webp` and `card-nikita.webp` exist in `images/homepage/` but no page
+  references them — the cards were built and then removed, or never added.
+- `images/global/logo-brown-no_bg-41230c.webp` is unreferenced.
+- `.DS_Store` files are committed at the repo root and in `images/`. Add a `.gitignore`.
+- Empty placeholder directories: `images/about/`, `images/global/`, `images/projects/project1/`.
+- **`CLAUDE.md` is out of date.** It documents `stylesheet.html`, `css/styles.css`,
+  `projects/project1.html` and `projects/project2.html` — none of which exist. It lists
+  token names (`--colour-background-{1,2}`, `--spacing-{s-64,m-96,l-144}`,
+  `--page-max-width-home`) that do not match `tokens.css`. Fix this early: it is the file
+  that tells an assistant how to work on this repo, and right now it is misleading.
+
+---
+
+## Suggested order
+
+1. **Stage 4 first** — the `noindex` on two unfinished public pages is the only finding
+   with a visible consequence for someone applying for jobs, and `CLAUDE.md` being wrong
+   makes every later session worse. Half an hour.
+2. **Stage 2 deletions** — dead classes, dead tokens, dead icon, the two hover-query
+   misses, the ID selectors. Purely subtractive, nothing to weigh up. An hour.
+3. **The `overflow-x: hidden` investigation** — you have an open bug that this probably
+   explains.
+4. **The fonts** — drop `ital`, narrow the weight ranges. Ten minutes for a real payload
+   win. Self-hosting is a bigger job; do it separately if you want it.
+5. **The `text-body` decision** — needs your call, and `CLAUDE.md` changes with it.
+6. **Stage 3 JS slimming** — the cursor and cycler cleanups. Lowest risk of the lot
+   because nothing about the visible behaviour changes.
+7. **`.stack`** — only if the CSS still feels repetitive after 2 and 5. It probably will
+   not.

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,10 +1,10 @@
 # Frontend audit
 
 Full read of all six HTML pages, seven CSS files and `js/main.js` (~2,800 lines).
-Stage 1 is already committed. Everything below it is proposed, not done.
+Stages 1 and 1b are committed. Everything below them is proposed, not done.
 
-Totals as they stand: **35 KB CSS**, **21 KB JS**, **56 distinct classes**, 37 sprite
-icons, two variable fonts from Google.
+Totals at the start: **35 KB CSS**, **21 KB JS** (523 lines), **56 distinct classes**,
+37 sprite icons, two variable fonts from Google. `main.js` is now 467 lines.
 
 ---
 
@@ -62,6 +62,75 @@ moving between case studies gets a different visual hierarchy on each. See Stage
   `main.js` says is unreliable. The region now exists on all six pages; the `aria-live`
   attributes are gone.
 - Two empty `<section>` elements in `nikita.html` rendering as blank padded space.
+
+---
+
+## Stage 1b — native HTML in place of JavaScript (committed)
+
+Every one of these was checked against the actual behaviour in a browser, not assumed.
+
+### Back to top: `<button>` + 12 lines of JS → `<a href="#main">`
+
+The old button called `window.scrollTo` with a reduced-motion check, then moved focus to
+`#main` so the next Tab continued from the top of the page. A plain anchor does **all of
+that natively**: the browser scrolls, honours the `scroll-behavior: smooth` already in
+`reset.css` (which is already wrapped in a reduced-motion guard), and moves focus to the
+target because `#main` carries `tabindex="-1"`.
+
+Verified: click → `scrollY: 0`, `document.activeElement` is `main`, next Tab lands on the
+first link inside `main`. Identical behaviour, and it now works with JavaScript disabled.
+
+### Hero details: `<ul>` → `<dl>`
+
+"Client / SINTEF Digital", "Role / UX designer" are name-value pairs, which is precisely
+what a description list is for. Each pair is now `<dt>`/`<dd>` grouped in a `<div>` (the
+sanctioned way to group them inside a `<dl>`). The `role="list"` workaround is no longer
+needed. No CSS changed.
+
+### Clipboard: dropped the `execCommand` fallback (~22 lines)
+
+The fallback built a hidden `<textarea>`, selected it, called the deprecated
+`document.execCommand('copy')`, then restored focus. It only ever mattered on plain
+`http://` or `file://`. The site is on HTTPS, where `navigator.clipboard` always exists,
+and the `mailto:` fallback already catches every failure. Four lines now.
+
+### Nav link handler: removed a 240ms delay and a dead branch (~14 lines → 7)
+
+The handler called `preventDefault()` and then `setTimeout(() => window.location.href =
+href, 240)` — a quarter-second added to every cross-page click, to animate a bar on a page
+that was about to unload. Gone; the browser navigates normally again.
+
+Its `else if` branch was **unreachable**. The only link it matches is either `#projects`
+or `../index.html#projects`, so the `href === currentPage` test could never be true, and
+the `#projects` case was excluded by the branch's own guard. What survives is the one part
+that mattered: hold the bar still for a second so the smooth scroll it triggers does not
+immediately hide the bar you just clicked.
+
+### `sectionLinkMap` / `sectionIds`: 10 lines → 1
+
+Ten lines of DOM walking built a map that was used for exactly one thing:
+`sectionIds.length > 0`. Now `[...navLinks].some(a => a.getAttribute('href').startsWith('#'))`.
+
+### What was tried and rejected: `<details>` for the mobile menu
+
+The obvious candidate — `<details>`/`<summary>` gives you the open/closed state,
+`aria-expanded` and keyboard support for free, deleting ~25 lines. **It does not work
+here**, and I tested rather than guessed.
+
+The menu has to be a plain row on desktop, which means forcing a closed `<details>` to
+show its content with CSS alone. It cannot be done: the browser hides the content via
+`content-visibility` on an internal slot, so even `display: flex !important` on the child
+leaves `checkVisibility()` returning `false`. Making it work needs JavaScript toggling the
+`open` attribute on resize — more code than the current implementation, not less.
+
+`<details>` would be the right call if the menu were mobile-only. It isn't.
+
+### Worth knowing for the lightbox on your TODO
+
+When you build it, use `<dialog>` with `showModal()`. You get the focus trap, Escape to
+close, the backdrop, and the rest of the page made inert — natively, for about five lines
+of JS instead of eighty. That is the single best modern-HTML win still available on this
+site, and it is in work you have not written yet.
 
 ---
 
@@ -168,13 +237,21 @@ DNS lookups, two TLS handshakes and a render-blocking third-party round trip fro
 page. That is a real chunk of your time-to-first-paint, and it is the single most
 effective "make it lightweight" change available.
 
+It also removes a fragility that showed up while auditing: when `fonts.googleapis.com` is
+unreachable, the entire visual identity falls back to `system-ui` and the page renders in
+a generic system sans. The `font-family` declarations are correct — the typography simply
+depends on a third party being reachable. Self-hosting makes that impossible.
+
 ---
 
 ## Stage 3 — JavaScript (proposed)
 
-`main.js` is 523 lines. Roughly 40% is the custom cursor. You have chosen to keep both
-the cursor and the footer cycler and slim them, which is the right instinct for a design
-portfolio — they are the personality, and personality is the product here.
+`main.js` is down to 467 lines after Stage 1b. Roughly half of what remains is the custom
+cursor. You have chosen to keep both the cursor and the footer cycler and slim them, which
+is the right instinct for a design portfolio — they are the personality, and personality is
+the product here.
+
+The navbar items in this stage are already done (see Stage 1b). What is left:
 
 ### Custom cursor (~150 lines JS, ~90 CSS)
 
@@ -201,22 +278,6 @@ portfolio — they are the personality, and personality is the product here.
 - 30 of the 37 sprite icons exist solely to feed this loop. That is fine if you like it
   (I think you do), but it means the 27 KB sprite is essentially a decorative asset. Worth
   knowing what it is buying.
-
-### Navbar (~70 lines)
-
-- `sectionLinkMap` and `sectionIds` are built with 10 lines of DOM walking, and the only
-  thing either is ever used for is `const isHomepage = sectionIds.length > 0`. Replace the
-  whole block with a `data-page="home"` attribute on `<body>`, or a single
-  `document.getElementById('projects')` check.
-- The nav-link handler **delays every navigation by 240ms** via
-  `setTimeout(() => window.location.href = href, 240)` after `preventDefault()`. This adds
-  a quarter-second to every click, and hand-rolling navigation loses the browser's own
-  handling. If the delay exists to let the bar animate, that animation is not worth 240ms
-  on every page change. My recommendation is to remove it.
-- `navLinks.forEach` runs before `suppressHide` and `suppressTimeout` are declared further
-  down the file. It works — `let` hoists into the temporal dead zone but the handler only
-  runs on click, long after declaration — but it reads as a bug and will trip up the next
-  person, including you in six months.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
       </div>
     </div>
 
-    <button type="button" class="button button--primary" data-scroll-top>Back to top <svg class="icon" aria-hidden="true"><use href="images/icons/sprite.svg#icon-arrow-up"/></svg></button>
+    <a href="#main" class="button button--primary">Back to top <svg class="icon" aria-hidden="true"><use href="images/icons/sprite.svg#icon-arrow-up"/></svg></a>
   
   </footer>
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
 
   <a href="#main" class="skip-link">Skip to main content</a>
 
+  <span class="visually-hidden" role="status" data-copy-status></span>
+
   <header class="navbar">
     <a href="index.html" class="navbar__logo text-subtitle text-stronger">Emma Shang Hansen</a>
     <button class="navbar__toggle" type="button" aria-expanded="false" aria-controls="navbar-links" aria-label="Open menu">
@@ -51,11 +53,11 @@
   <div class="main-content">
 
     <section id="home-hero" class="page-container hero-heading">
-      <h1 class="text-display text-stronger">Emma is a <span class="text-display text-underline">UX designer</span> and <span class="text-display text-underline">tech enthusiast</span></h1>
+      <h1 class="text-display text-stronger">Emma is a <span class="text-underline">UX designer</span> and <span class="text-underline">tech enthusiast</span></h1>
       <p class="text-subtitle text-subtle">Currently designing maritime navigation displays and internal tools at <a href="https://www.jotron.com/" target="_blank" rel="noopener" class="text-link">Jotron</a>.</p>
     </section>
 
-    <section id="projects" aria-labelledby="projects-heading">
+    <section id="projects" aria-label="Projects">
       <div class="page-container">
 
         <ul class="projects-grid" role="list">
@@ -64,7 +66,7 @@
             <div class="project-card__image"><img src="images/homepage/card-pocus.webp" alt="AI POCUS AAA, in collaboration with SINTEF and NTNU, over a photo of a researcher guiding an ultrasound exam on a laptop" width="960" height="520"><a class="project-card__link" href="projects/pocus.html" aria-hidden="true" tabindex="-1"></a></div>
             <div class="project-card__info">
               <div class="project-card__body">
-                <h3 class="text-subtitle text-stronger">Helping doctors perform ultrasound examinations with AI guidance</h3>
+                <h2 class="text-subtitle text-stronger">Helping doctors perform ultrasound examinations with AI guidance</h2>
                 <p class="text-body">Worked with SINTEF to design an AI tool which guides doctors through ultrasound examinations. The tool is being used in their 2026 clinical trials.</p>
               </div>
               <div class="project-card__footer">
@@ -76,7 +78,7 @@
             <div class="project-card__image"><img src="images/homepage/card-medication-administration.webp" alt="A LEGO prototype of a medicine cart labelled &quot;PC&quot; and &quot;MEDISIN TRALLE&quot;, with a nurse minifigure standing beside it" width="960" height="520"><a class="project-card__link" href="projects/medication.html" aria-hidden="true" tabindex="-1"></a></div>
             <div class="project-card__info">
               <div class="project-card__body">
-                <h3 class="text-subtitle text-stronger">Safer medication administration for nurses</h3>
+                <h2 class="text-subtitle text-stronger">Safer medication administration for nurses</h2>
                 <p class="text-body">Service design project redesigning a nursing home's medication routine, focusing on value and feasibility.</p>
               </div>
               <div class="project-card__footer">
@@ -88,7 +90,7 @@
             <div class="project-card__image"><img src="images/homepage/card-jotron.webp" alt="The Jotron logo: the company name in navy capitals beside a striped blue globe" width="960" height="520"></div>
             <div class="project-card__info">
               <div class="project-card__body">
-                <h3 class="text-subtitle text-stronger">Designing productivity tools for Jotron</h3>
+                <h2 class="text-subtitle text-stronger">Designing productivity tools for Jotron</h2>
                 <p class="text-body">Working closely with developers to design and build tools for handling large data sets and manage documents. Scheduled to go live in September 2026.</p>
               </div>
               <div class="project-card__footer">
@@ -100,7 +102,7 @@
             <div class="project-card__image"><img src="images/homepage/card-rat.webp" alt="The game&#39;s title card: &quot;Rat with a Postman Hat&quot; in orange lettering under a blue postman cap, above a wooden sign reading &quot;Best Narrative&quot;, on a dark teal brick wall" width="960" height="520"><a class="project-card__link" href="projects/rat.html" aria-hidden="true" tabindex="-1"></a></div>
             <div class="project-card__info">
               <div class="project-card__body">
-                <h3 class="text-subtitle text-stronger">Designing an award-winning story game</h3>
+                <h2 class="text-subtitle text-stronger">Designing an award-winning story game</h2>
                 <p class="text-body">I was in charge of storytelling, level design and more, for a game that won Best Narrative at Norwegian Game Awards 2024.</p>
               </div>
               <div class="project-card__footer">
@@ -117,8 +119,6 @@
   </main>
 
   <footer class="footer">
-    <span class="visually-hidden" role="status" data-copy-status></span>
-
     <div class="footer__text">
       <p class="text-body">Created with <span class="visually-hidden">love</span> <svg id="footer-cycling-icon" class="icon" aria-hidden="true"><use href="images/icons/sprite.svg#icon-heart"/></svg> <strong>Emma Shang Hansen</strong></p>
       <div class="footer__links">

--- a/js/main.js
+++ b/js/main.js
@@ -218,45 +218,25 @@ if (navToggle && navPanel) {
   });
 }
 
-navLinks.forEach(link => {
-  link.addEventListener('click', e => {
-    // Cmd/Ctrl/Shift-click and middle-click belong to the browser, not to us
-    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
-    const href = link.getAttribute('href');
-    suppressHide = true;
-    navbar.classList.remove('navbar--hidden');
-    clearTimeout(suppressTimeout);
-    suppressTimeout = setTimeout(() => { suppressHide = false; }, 1000);
-    const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-    const isSamePage = href.startsWith('#') || href === currentPage;
-    if (!isSamePage) {
-      e.preventDefault();
-      setTimeout(() => { window.location.href = href; }, 240);
-    } else if (!href.startsWith('#')) {
-      e.preventDefault();
-      scrollToTop();
-    }
-  });
-});
-
-// Detect homepage (has in-page section links) — feeds isHomepage below
-const sectionLinkMap = {};
-navLinks.forEach(a => {
-  const href = a.getAttribute('href');
-  if (href && href.startsWith('#')) {
-    const section = document.getElementById(href.slice(1));
-    if (section) sectionLinkMap[href.slice(1)] = a;
-  }
-});
-const sectionIds = Object.keys(sectionLinkMap);
-
 // Hide navbar on scroll down, show on scroll up
 // Always on project pages; on homepage only on mobile (≤768px)
 let lastScrollY = window.scrollY;
 let suppressHide = false;
 let suppressTimeout;
 
-const isHomepage = sectionIds.length > 0;
+// The homepage is the one whose nav links point at sections of the page itself.
+const isHomepage = [...navLinks].some(a => a.getAttribute('href').startsWith('#'));
+
+// Following a nav link holds the bar in place for a moment, so the smooth scroll
+// it triggers doesn't immediately hide the bar you just used.
+navLinks.forEach(link => {
+  link.addEventListener('click', () => {
+    suppressHide = true;
+    navbar.classList.remove('navbar--hidden');
+    clearTimeout(suppressTimeout);
+    suppressTimeout = setTimeout(() => { suppressHide = false; }, 1000);
+  });
+});
 
 window.addEventListener('scroll', () => {
   if (isHomepage && wideQuery.matches) return;
@@ -332,21 +312,6 @@ if (footerIcon) {
   cycleFooterIcon();
 }
 
-// --- Back to top ---
-// Focus follows the scroll, so the next Tab continues from the top of the page
-// instead of the footer the button sits in.
-function scrollToTop() {
-  const behavior = matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth';
-  window.scrollTo({ top: 0, behavior });
-}
-
-document.querySelectorAll('[data-scroll-top]').forEach(button => {
-  button.addEventListener('click', () => {
-    scrollToTop();
-    document.getElementById('main')?.focus({ preventScroll: true });
-  });
-});
-
 // --- Copy email ---
 // The address goes to the clipboard rather than handing off to a mail client:
 // most people read mail in a browser tab, so a mailto: tends to open some
@@ -355,33 +320,12 @@ document.querySelectorAll('[data-scroll-top]').forEach(button => {
 const COPIED_MS = 1600; // long enough to register, short enough not to linger
 
 async function copyToClipboard(text) {
-  if (navigator.clipboard) {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch {
-      // Permission denied, or an insecure context — try the legacy route.
-    }
-  }
-
-  // Deprecated, but still the only path on a plain http:// or file:// page.
-  const previousFocus = document.activeElement;
-  const field = document.createElement('textarea');
-  field.value = text;
-  field.readOnly = true;
-  field.style.cssText = 'position:fixed; top:0; left:0; opacity:0;';
-  document.body.appendChild(field);
-  field.select();
-  field.setSelectionRange(0, text.length); // iOS ignores select() on its own
-  let copied = false;
   try {
-    copied = document.execCommand('copy');
+    await navigator.clipboard.writeText(text);
+    return true;
   } catch {
-    copied = false;
+    return false; // no clipboard, or permission refused — the caller falls back to mailto:
   }
-  field.remove();
-  previousFocus?.focus({ preventScroll: true });
-  return copied;
 }
 
 const copyStatus = document.querySelector('[data-copy-status]');

--- a/projects/medication.html
+++ b/projects/medication.html
@@ -60,24 +60,24 @@
       <div class="project-hero__image">
         <img src="../images/projects/medication/hero.webp" width="2240" height="1260" alt="A LEGO model of a nursing home room: lime-green walls, a tile labelled &quot;PC&quot;, a medicine cart labelled &quot;MEDISIN TRALLE&quot;, and a nurse minifigure standing beside it">
       </div>
-      <ul class="project-hero__details-grid" role="list">
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Role</p>
-          <p class="text-body">Service designer</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Team</p>
-          <p class="text-body">5 designers</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">My contribution</p>
-          <p class="text-body">Research<br>Concept design<br>User testing</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Timeline</p>
-          <p class="text-body">Semester project</p>
-        </li>
-      </ul>
+      <dl class="project-hero__details-grid">
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Role</dt>
+          <dd class="text-body">Service designer</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Team</dt>
+          <dd class="text-body">5 designers</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">My contribution</dt>
+          <dd class="text-body">Research<br>Concept design<br>User testing</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Timeline</dt>
+          <dd class="text-body">Semester project</dd>
+        </div>
+      </dl>
     </section>
 
     <!-- Background -->
@@ -155,9 +155,9 @@
     </section>
 
     <div class="scroll-top-slot">
-      <button type="button" class="button button--primary button--no-dock scroll-top" aria-label="Back to top" data-scroll-top>
+      <a href="#main" class="button button--primary button--no-dock scroll-top" aria-label="Back to top">
         <svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-up"/></svg>
-      </button>
+      </a>
     </div>
 
     <nav class="project-footer" aria-label="Case studies">

--- a/projects/medication.html
+++ b/projects/medication.html
@@ -31,6 +31,8 @@
 
   <a href="#main" class="skip-link">Skip to main content</a>
 
+  <span class="visually-hidden" role="status" data-copy-status></span>
+
   <header class="navbar">
     <a href="../index.html" class="navbar__logo text-subtitle text-stronger">Emma Shang Hansen</a>
     <button class="navbar__toggle" type="button" aria-expanded="false" aria-controls="navbar-links" aria-label="Open menu">
@@ -38,7 +40,7 @@
     </button>
     <nav id="navbar-links" class="navbar__links" aria-label="Main">
       <a href="../index.html#projects" class="button button--tertiary">Projects</a>
-      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com" aria-live="polite">
+      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com">
         <span class="button__labels">
           <span>Copy email</span>
           <span aria-hidden="true">Email copied</span>
@@ -100,10 +102,10 @@
     <section class="project-section">
       <h3 class="text-title">A morning shift at a nursing home</h3>
       <p class="text-body">One team member had a contact at a local nursing home, which gave her access to shadow a real shift. She expected to observe frustrations with software. Instead she saw handwritten notes, post-it reminders, manual counting. The single PC was in the office, so checking the journal meant leaving the medicine cart. Everyone had their own way of doing it. The workflow was the bottleneck.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/medication/body-medication.webp" width="2400" height="1552" alt="A user journey map for nursing home staff, in Norwegian, laid out in three swimlanes with red markers on the pain points" loading="lazy">
         <!-- TODO: caption -->
-      </div>
+      </figure>
     </section>
 
     <!-- Ideation -->
@@ -118,36 +120,36 @@
       </ul>
       <p class="text-body">Rather than creating another overambitious student app, we asked:</p>
       <p class="text-body">What would make the existing routine less error-prone and easier to hand off between staff? One shared routine, with digital tools placed where the work actually happens.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/medication/body-medication-1.webp" width="2400" height="2008" alt="An impact and effort matrix of the idea bank, in Norwegian, with sticky notes and sketches arranged in a staircase from low to high impact" loading="lazy">
         <!-- TODO: caption -->
-      </div>
+      </figure>
     </section>
 
     <!-- Testing the workflow -->
     <section class="project-section">
       <h3 class="text-title">Testing the workflow</h3>
       <p class="text-body">After an early feedback session with nurses, using a Lego model of the department, we had fellow students simulate the workflow, distributing fruit instead of medicine to remove any familiarity barrier. With paper notes and the old routine, participants improvised their own methods, forgot to sign off medication, and rushed between rooms.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/medication/body-medication-2.webp" width="2400" height="1630" alt="A LEGO model of the department: green baseplate rooms with a medicine cart labelled &quot;MEDISIN TRALLE&quot;, a tile labelled &quot;PC&quot;, and a nurse minifigure" loading="lazy">
         <!-- TODO: caption -->
-      </div>
+      </figure>
       <p class="text-body">With simple digital tools and a shared routine, everyone followed the same structure. Nobody forgot to sign off, and there was noticeably less interruption and stress.</p>
       <p class="text-body">Several participants even paused to ask patient Kari how she was doing. In the first round, nobody did.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/medication/body-medication-3.webp" width="2400" height="1156" alt="Two photographs from the workflow simulation: a participant handing over a paper note, and two participants working through the routine with patient name cards laid out on the table" loading="lazy">
         <!-- TODO: caption -->
-      </div>
+      </figure>
     </section>
 
     <!-- What we landed on -->
     <section class="project-section">
       <h3 class="text-title">What we landed on</h3>
       <p class="text-body">The final concept was a set of requirements applicable for most departments: a shared routine with someone responsible for keeping it consistent, digital sign-off for safer record-keeping, a PC near the medicine cart for easy lookups, among other requirements aimed at reducing uncertainty and manual counting.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/medication/body-medication-4.webp" width="2400" height="1414" alt="A five-panel storyboard of the proposed routine, from accessing patient records at the medication cart through to confirming the given medications digitally" loading="lazy">
-        <p class="text-caption text-subtle">Redesigned medication administration routine</p>
-      </div>
+        <figcaption class="text-caption text-subtle">Redesigned medication administration routine</figcaption>
+      </figure>
       <p class="text-body">The nurse we had shadowed reviewed the concept during validation and gave feedback on feasibility. We didn't reach management or secure formal sign-off, so whether anything was implemented remains unknown. Our goal had been to design something grounded and feasible with no new infrastructure or budget required.</p>
       <p class="text-body">According to our supervisor, outside actors tend to focus on large projects and new technology. But developing better working routines is a small, important area that usually falls to busy nurses to improve themselves. This project reminds me that small changes can have substantial impact too.</p>
     </section>
@@ -158,14 +160,14 @@
       </button>
     </div>
 
-    <div class="project-footer">
+    <nav class="project-footer" aria-label="Case studies">
       <a href="pocus.html" class="button button--secondary project-footer__previous" aria-label="Previous project: Helping doctors perform ultrasound examinations with AI guidance"><svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-left"/></svg><span>Previous project</span></a>
       <div class="project-footer__text">
         <p class="text-subtitle">Rat with a Postman Hat</p>
         <p class="text-caption text-subtle">Storytelling, dialogue, level design and music</p>
       </div>
       <a href="rat.html" class="button button--primary" aria-label="Next project: Rat with a Postman Hat"><span>Next project</span><svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-right"/></svg></a>
-    </div>
+    </nav>
 
   </div>
   </main>

--- a/projects/nga.html
+++ b/projects/nga.html
@@ -31,6 +31,8 @@
 
   <a href="#main" class="skip-link">Skip to main content</a>
 
+  <span class="visually-hidden" role="status" data-copy-status></span>
+
   <header class="navbar">
     <a href="../index.html" class="navbar__logo text-subtitle text-stronger">Emma Shang Hansen</a>
     <button class="navbar__toggle" type="button" aria-expanded="false" aria-controls="navbar-links" aria-label="Open menu">
@@ -38,7 +40,7 @@
     </button>
     <nav id="navbar-links" class="navbar__links" aria-label="Main">
       <a href="../index.html#projects" class="button button--tertiary">Projects</a>
-      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com" aria-live="polite">
+      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com">
         <span class="button__labels">
           <span>Copy email</span>
           <span aria-hidden="true">Email copied</span>
@@ -88,10 +90,10 @@
       <h2 class="text-subtitle text-subtle">Process</h2>
       <p class="text-body">This was an open problem with few hard constraints, which meant the whole team could contribute meaningfully from the start. Rather than moving straight to solutions, we each stated our unbiased personal read on the problem first. The goal was to surface where our assumptions aligned and where they diverged, then reach a shared understanding before defining the brief.</p>
       <p class="text-body">For learning the tool, the approach was direct: make something. We produced a new Figma sketch every meeting, which turned iteration into practice.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/placeholder.svg" alt="" width="1200" height="800" loading="lazy">
-        <p class="text-caption text-subtle">Early working sketches or a photo from a team alignment session</p>
-      </div>
+        <figcaption class="text-caption text-subtle">Early working sketches or a photo from a team alignment session</figcaption>
+      </figure>
     </section>
 
     <!-- Shaping the brief -->
@@ -110,10 +112,10 @@
       <h3 class="text-subtitle text-stronger">The game-levels roadmap</h3>
       <p class="text-body">At one point I considered a roadmap that looked like game levels — on theme, memorable, and genuinely fun. I decided against it. NGA needed to be able to maintain the site independently. Building something that required specialist knowledge to update every year would mean it'd be outdated within months of handoff. I'd rather build something that outlasts the project than something that impresses during delivery.</p>
 
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/placeholder.svg" alt="" width="1200" height="800" loading="lazy">
-        <p class="text-caption text-subtle">Wireframes or brief notes showing these decisions being worked through</p>
-      </div>
+        <figcaption class="text-caption text-subtle">Wireframes or brief notes showing these decisions being worked through</figcaption>
+      </figure>
     </section>
 
     <!-- Solution -->
@@ -121,14 +123,14 @@
       <h2 class="text-subtitle text-subtle">Solution</h2>
       <p class="text-body">The visual identity moved from uninspiring grey and muddy green to punchy green on dark blue. Critical information — deadlines, how to participate — is visible in the hero section, with a clear call to action to register. Navigation is clearer, information is easier to find, and the hierarchy on each page does the work that long paragraphs used to bury.</p>
       <p class="text-body">Outside of formal project scope, I also gave the previous winners page a cleanup it badly needed.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/placeholder.svg" alt="" width="1200" height="800" loading="lazy">
-        <p class="text-caption text-subtle">Before / after — homepage</p>
-      </div>
-      <div class="project-section__image">
+        <figcaption class="text-caption text-subtle">Before / after — homepage</figcaption>
+      </figure>
+      <figure class="project-section__image">
         <img src="../images/projects/placeholder.svg" alt="" width="1200" height="800" loading="lazy">
-        <p class="text-caption text-subtle">Before / after — information page or winners page</p>
-      </div>
+        <figcaption class="text-caption text-subtle">Before / after — information page or winners page</figcaption>
+      </figure>
     </section>
 
     <!-- Outcome -->
@@ -152,14 +154,14 @@
       </button>
     </div>
 
-    <div class="project-footer">
+    <nav class="project-footer" aria-label="Case studies">
       <a href="rat.html" class="button button--secondary project-footer__previous" aria-label="Previous project: Rat with a Postman Hat"><svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-left"/></svg><span>Previous project</span></a>
       <div class="project-footer__text">
         <p class="text-subtitle">Nikita Hair</p>
         <p class="text-caption text-subtle">Led the redesign of their online booking flow</p>
       </div>
       <a href="nikita.html" class="button button--primary" aria-label="Next project: Nikita Hair"><span>Next project</span><svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-right"/></svg></a>
-    </div>
+    </nav>
 
   </div>
   </main>

--- a/projects/nga.html
+++ b/projects/nga.html
@@ -60,20 +60,20 @@
       <div class="project-hero__image">
         <img src="../images/projects/placeholder.svg" alt="" width="1600" height="900">
       </div>
-      <ul class="project-hero__details-grid" role="list">
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Organisation</p>
-          <p class="text-body">Designhjelpen</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">My role</p>
-          <p class="text-body">Project lead, design, Webflow</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Team</p>
-          <p class="text-body">4 people</p>
-        </li>
-      </ul>
+      <dl class="project-hero__details-grid">
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Organisation</dt>
+          <dd class="text-body">Designhjelpen</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">My role</dt>
+          <dd class="text-body">Project lead, design, Webflow</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Team</dt>
+          <dd class="text-body">4 people</dd>
+        </div>
+      </dl>
     </section>
 
     <!-- The problem -->
@@ -149,9 +149,9 @@
     </section>
 
     <div class="scroll-top-slot">
-      <button type="button" class="button button--primary button--no-dock scroll-top" aria-label="Back to top" data-scroll-top>
+      <a href="#main" class="button button--primary button--no-dock scroll-top" aria-label="Back to top">
         <svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-up"/></svg>
-      </button>
+      </a>
     </div>
 
     <nav class="project-footer" aria-label="Case studies">

--- a/projects/nikita.html
+++ b/projects/nikita.html
@@ -31,6 +31,8 @@
 
   <a href="#main" class="skip-link">Skip to main content</a>
 
+  <span class="visually-hidden" role="status" data-copy-status></span>
+
   <header class="navbar">
     <a href="../index.html" class="navbar__logo text-subtitle text-stronger">Emma Shang Hansen</a>
     <button class="navbar__toggle" type="button" aria-expanded="false" aria-controls="navbar-links" aria-label="Open menu">
@@ -38,7 +40,7 @@
     </button>
     <nav id="navbar-links" class="navbar__links" aria-label="Main">
       <a href="../index.html#projects" class="button button--tertiary">Projects</a>
-      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com" aria-live="polite">
+      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com">
         <span class="button__labels">
           <span>Copy email</span>
           <span aria-hidden="true">Email copied</span>
@@ -83,21 +85,15 @@
       <p class="text-body">The overarching challenge my team faced in this project, was technical limitations presented by this underlying system</p>
     </section>
 
-    <section class="project-section">
-    </section>
-
-    <section class="project-section">
-    </section>
-
     <div class="scroll-top-slot">
       <button type="button" class="button button--primary button--no-dock scroll-top" aria-label="Back to top" data-scroll-top>
         <svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-up"/></svg>
       </button>
     </div>
 
-    <div class="project-footer">
+    <nav class="project-footer" aria-label="Case studies">
       <a href="nga.html" class="button button--secondary project-footer__previous" aria-label="Previous project: Norwegian Game Awards"><svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-left"/></svg><span>Previous project</span></a>
-    </div>
+    </nav>
 
   </div>
   </main>

--- a/projects/nikita.html
+++ b/projects/nikita.html
@@ -60,20 +60,20 @@
       <div class="project-hero__image">
         <img src="../images/projects/placeholder.svg" alt="" width="1600" height="900">
       </div>
-      <ul class="project-hero__details-grid" role="list">
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Client</p>
-          <p class="text-body">Nikita Hair</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">My contribution</p>
-          <p class="text-body">User research, Interaction design, Experience design, Project management</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Team</p>
-          <p class="text-body">Emma Shang Hansen (me), Brage Berg, Anne Selseng, Nanna Gleditsch, Sofie Røstum, Malin Iversen</p>
-        </li>
-      </ul>
+      <dl class="project-hero__details-grid">
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Client</dt>
+          <dd class="text-body">Nikita Hair</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">My contribution</dt>
+          <dd class="text-body">User research, Interaction design, Experience design, Project management</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Team</dt>
+          <dd class="text-body">Emma Shang Hansen (me), Brage Berg, Anne Selseng, Nanna Gleditsch, Sofie Røstum, Malin Iversen</dd>
+        </div>
+      </dl>
     </section>
 
     <section class="project-section">
@@ -86,9 +86,9 @@
     </section>
 
     <div class="scroll-top-slot">
-      <button type="button" class="button button--primary button--no-dock scroll-top" aria-label="Back to top" data-scroll-top>
+      <a href="#main" class="button button--primary button--no-dock scroll-top" aria-label="Back to top">
         <svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-up"/></svg>
-      </button>
+      </a>
     </div>
 
     <nav class="project-footer" aria-label="Case studies">

--- a/projects/pocus.html
+++ b/projects/pocus.html
@@ -31,6 +31,8 @@
 
   <a href="#main" class="skip-link">Skip to main content</a>
 
+  <span class="visually-hidden" role="status" data-copy-status></span>
+
   <header class="navbar">
     <a href="../index.html" class="navbar__logo text-subtitle text-stronger">Emma Shang Hansen</a>
     <button class="navbar__toggle" type="button" aria-expanded="false" aria-controls="navbar-links" aria-label="Open menu">
@@ -38,7 +40,7 @@
     </button>
     <nav id="navbar-links" class="navbar__links" aria-label="Main">
       <a href="../index.html#projects" class="button button--tertiary">Projects</a>
-      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com" aria-live="polite">
+      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com">
         <span class="button__labels">
           <span>Copy email</span>
           <span aria-hidden="true">Email copied</span>
@@ -97,10 +99,10 @@
         <li class="text-body">A video prototype, exploring the ideal scenario with features doctors actually needed.</li>
       </ul>
       <p class="text-body">This decision kept the team focused, and gave us richer feedback than any single prototype would have.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/pocus/01-prototypes-ideal-vs-mvp.webp" width="2400" height="1800" alt="The ideal prototype above, showing the full guidance interface, and the simplified MVP below, used for live AI testing" loading="lazy">
-        <p class="text-caption text-subtle">Top: Ideal prototype, showing complete UI with additional features. Bottom: MVP used for testing the AI live.</p>
-      </div>
+        <figcaption class="text-caption text-subtle">Top: Ideal prototype, showing complete UI with additional features. Bottom: MVP used for testing the AI live.</figcaption>
+      </figure>
     </section>
 
     <!-- Challenge -->
@@ -108,10 +110,10 @@
       <h2 class="text-subtitle text-subtle">Challenge</h2>
       <h3 class="text-title">Lack of confidence and trust</h3>
       <p class="text-body">I came in with no ultrasound knowledge, like the target users. I observed experts, practised on colleagues, and briefly wondered where the challenge was. Until I talked with GPs. For them, a misdiagnosis can have severe consequences, and some feel that they can't afford to experiment. One doctor stated that mental barriers was the main reason they were hesitant. Beyond simply teaching the procedure, I realised the purpose of the tool should be help them feel confident in their decisions.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/pocus/02-doctor-quotes.webp" width="1200" height="560" alt="Three quotes from doctors: &quot;We're scared to misdiagnose the patient.&quot; &quot;That looks very difficult…&quot; &quot;No one likes drinking coffee the first time.&quot;" loading="lazy">
-        <p class="text-caption text-subtle">Quotes from doctors during interviews and workshops.</p>
-      </div>
+        <figcaption class="text-caption text-subtle">Quotes from doctors during interviews and workshops.</figcaption>
+      </figure>
     </section>
 
     <!-- Testing early -->
@@ -119,35 +121,35 @@
       <h2 class="text-subtitle text-subtle">Testing early</h2>
       <h3 class="text-title">Start building before the AI is ready</h3>
       <p class="text-body">An AI still in training is unpredictable. Early on, we didn't know its exact capabilities, or how it would behave. Instead of waiting, I simulated its behaviour through role-plays, storyboards and early prototypes. Gathered insight was fed back into the AI's development. After seeing it failing to identify smaller, healthier aortas, we prioritised training it on more varied patient data.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/pocus/03-user-test-setup.webp" width="2400" height="1592" alt="A test session: the doctor scans a volunteer while the prototype runs on a laptop beside them and mirrors onto a wall screen" loading="lazy">
-        <p class="text-caption text-subtle">Picture from one of the early user tests. The user (1). On the user's left side, laptop with prototype, accompanied by a developer (3) simulating the AI. On the user's right side, the "patient" (4).</p>
-      </div>
+        <figcaption class="text-caption text-subtle">Picture from one of the early user tests. The user (1). On the user's left side, laptop with prototype, accompanied by a developer (3) simulating the AI. On the user's right side, the "patient" (4).</figcaption>
+      </figure>
     </section>
 
     <!-- Final result -->
     <section class="project-section">
       <h2 class="text-subtitle text-subtle">Final result</h2>
       <h3 class="text-title">An AI-guided workflow for AAA examinations</h3>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/pocus/04-laptop-and-probe.webp" width="2400" height="1600" alt="The guidance interface running on a laptop, beside the handheld ultrasound probe it works with" loading="lazy">
-        <p class="text-caption text-subtle">The MVP running on a laptop, beside the handheld probe it pairs with. The interface is in Norwegian — the prompt here reads "keep the aorta centred, scan downward".</p>
-      </div>
-      <div class="project-section__image">
+        <figcaption class="text-caption text-subtle">The MVP running on a laptop, beside the handheld probe it pairs with. The interface is in Norwegian — the prompt here reads "keep the aorta centred, scan downward".</figcaption>
+      </figure>
+      <figure class="project-section__image">
         <img src="../images/projects/pocus/05-centred-and-measurement.webp" width="2400" height="1178" alt="Two interface states: a confirmation that the aorta is centred, and the automatic diameter measurement reading 27 mm" loading="lazy">
-        <p class="text-caption text-subtle">Left: confirmation that the aorta is centred, held for two seconds before the phase advances. Right: the automatic measurement, which the user can approve, edit by hand, or recalculate.</p>
-      </div>
-      <div class="project-section__image">
+        <figcaption class="text-caption text-subtle">Left: confirmation that the aorta is centred, held for two seconds before the phase advances. Right: the automatic measurement, which the user can approve, edit by hand, or recalculate.</figcaption>
+      </figure>
+      <figure class="project-section__image">
         <img src="../images/projects/pocus/06-interface-icons.webp" width="2400" height="640" alt="Four interface icons: probe, freeze, AI and confirm" loading="lazy">
-        <p class="text-caption text-subtle">Colour carries state throughout: yellow for the probe, blue for anything the AI is doing or a frozen image, green for a completed step.</p>
-      </div>
+        <figcaption class="text-caption text-subtle">Colour carries state throughout: yellow for the probe, blue for anything the AI is doing or a frozen image, green for a completed step.</figcaption>
+      </figure>
     </section>
 
     <!-- Step 1 -->
     <section class="project-section">
       <h4 class="text-subtitle text-stronger">Step 1: Finding aorta</h4>
       <p class="text-body">Tilt the probe. Aorta will be highlighted by AI when it enters the image.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <div class="project-video">
           <img src="../images/projects/pocus/07-step-1-find-aorta.webp" width="2400" height="1352" alt="Step 1 of the interface: the AI searches while prompting the user to rock the probe slowly" loading="lazy">
           <video data-src="../videos/projects/pocus/07-step-1-find-aorta.mp4" preload="none" muted loop playsinline></video>
@@ -160,15 +162,15 @@
             </button>
           </div>
         </div>
-        <p class="text-caption text-subtle">The AI searches while the illustration demonstrates the motion — "vugg sakte", rock slowly. Yellow brackets mark where to look.</p>
-      </div>
+        <figcaption class="text-caption text-subtle">The AI searches while the illustration demonstrates the motion — "vugg sakte", rock slowly. Yellow brackets mark where to look.</figcaption>
+      </figure>
     </section>
 
     <!-- Step 2 -->
     <section class="project-section">
       <h4 class="text-subtitle text-stronger">Step 2: Scanning</h4>
       <p class="text-body">Follow the aorta down, while the AI continuously measures the diameter.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <div class="project-video">
           <img src="../images/projects/pocus/08-step-2-scan-aorta.webp" width="2400" height="1352" alt="Step 2: the AI tracks the aorta and prompts the user to slide the probe to centre it" loading="lazy">
           <video data-src="../videos/projects/pocus/08-step-2-scan-aorta.mp4" preload="none" muted loop playsinline></video>
@@ -181,15 +183,15 @@
             </button>
           </div>
         </div>
-        <p class="text-caption text-subtle">The AI has found the aorta, highlighted red near the edge of the image, and asks the user to slide the probe toward the indicator to centre it.</p>
-      </div>
+        <figcaption class="text-caption text-subtle">The AI has found the aorta, highlighted red near the edge of the image, and asks the user to slide the probe toward the indicator to centre it.</figcaption>
+      </figure>
     </section>
 
     <!-- Step 3 -->
     <section class="project-section">
       <h4 class="text-subtitle text-stronger">Step 3: Measuring</h4>
       <p class="text-body">Upon freezing the image, AI automatically measures the diameter. Procedure complete.</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <div class="project-video">
           <img src="../images/projects/pocus/09-step-3-measure.webp" width="2400" height="1352" alt="Step 3: the diameter reads 27 mm, above the 26 mm threshold, and the interface prompts the user to freeze" loading="lazy">
           <video data-src="../videos/projects/pocus/09-step-3-measure.mp4" preload="none" muted loop playsinline></video>
@@ -202,12 +204,12 @@
             </button>
           </div>
         </div>
-        <p class="text-caption text-subtle">The diameter reads 27 mm, above the 26 mm threshold, so the interface prompts a freeze to take the measurement.</p>
-      </div>
-      <div class="project-section__image">
+        <figcaption class="text-caption text-subtle">The diameter reads 27 mm, above the 26 mm threshold, so the interface prompts a freeze to take the measurement.</figcaption>
+      </figure>
+      <figure class="project-section__image">
         <img src="../images/projects/pocus/10-goal-reframe.webp" width="2400" height="1782" alt="The measurement UI before and after reframing: the first version shows the AI's full reasoning, the second shows only whether to freeze" loading="lazy">
-        <p class="text-caption text-subtle">Reframing the goal from "help the user relocate the largest diameter" to "help the user know when to freeze". The first version showed everything the AI was considering; testers called it "too much going on".</p>
-      </div>
+        <figcaption class="text-caption text-subtle">Reframing the goal from "help the user relocate the largest diameter" to "help the user know when to freeze". The first version showed everything the AI was considering; testers called it "too much going on".</figcaption>
+      </figure>
     </section>
 
     <!-- Final testing -->
@@ -216,10 +218,10 @@
       <h3 class="text-title">Live prototype testing with 12 doctors</h3>
       <p class="text-body">The team and I travelled rural Norway, visiting 8 different doctor's offices. I interviewed and tested with 12 end users, and 3 other stakeholders.</p>
       <p class="text-body">Feedback indicated that more steps should be automated, instead of asking for user input. All users managed to complete the procedure with guidance, and repetition improved users' confidence drastically. Compared to when they tried on their own, several felt unsure if it was successful. Many expressed enthusiasm for the guidance, saying "Really easy with AI".</p>
-      <div class="project-section__image">
+      <figure class="project-section__image">
         <img src="../images/projects/pocus/11-testing-locations.webp" width="2400" height="1416" alt="A map of the region visited, marking Kristiansund four times, Aure twice, Rindal once and Surnadal once, beside photographs from the test sessions" loading="lazy">
-        <p class="text-caption text-subtle">The eight offices visited, and sessions in progress. Faces blurred for privacy.</p>
-      </div>
+        <figcaption class="text-caption text-subtle">The eight offices visited, and sessions in progress. Faces blurred for privacy.</figcaption>
+      </figure>
     </section>
 
     <!-- Reflecting -->
@@ -245,13 +247,13 @@
       </button>
     </div>
 
-    <div class="project-footer">
+    <nav class="project-footer" aria-label="Case studies">
       <div class="project-footer__text">
         <p class="text-subtitle">Safer medication administration</p>
         <p class="text-caption text-subtle">Research synthesis, concept refinement and testing</p>
       </div>
       <a href="medication.html" class="button button--primary" aria-label="Next project: Safer medication administration"><span>Next project</span><svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-right"/></svg></a>
-    </div>
+    </nav>
 
   </div>
   </main>

--- a/projects/pocus.html
+++ b/projects/pocus.html
@@ -60,25 +60,25 @@
       <div class="project-hero__image">
         <img src="../images/projects/pocus/hero.webp" width="2130" height="1200" alt="AI POCUS AAA, in collaboration with SINTEF and NTNU, over a photo of a researcher guiding an ultrasound exam on a laptop">
       </div>
-      <ul class="project-hero__details-grid" role="list">
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Client</p>
-          <p class="text-body">SINTEF Digital</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Role</p>
-          <p class="text-body">UX designer</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Team</p>
-          <p class="text-body">1 designer<br>2 developers<br>2 PMs</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">My contributions</p>
-          <p class="text-body">User research, Interaction design, Experience design, Project management</p>
-        </li>
+      <dl class="project-hero__details-grid">
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Client</dt>
+          <dd class="text-body">SINTEF Digital</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Role</dt>
+          <dd class="text-body">UX designer</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Team</dt>
+          <dd class="text-body">1 designer<br>2 developers<br>2 PMs</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">My contributions</dt>
+          <dd class="text-body">User research, Interaction design, Experience design, Project management</dd>
+        </div>
 
-      </ul>
+      </dl>
     </section>
 
     <!-- Background -->
@@ -242,9 +242,9 @@
     </section>
 
     <div class="scroll-top-slot">
-      <button type="button" class="button button--primary button--no-dock scroll-top" aria-label="Back to top" data-scroll-top>
+      <a href="#main" class="button button--primary button--no-dock scroll-top" aria-label="Back to top">
         <svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-up"/></svg>
-      </button>
+      </a>
     </div>
 
     <nav class="project-footer" aria-label="Case studies">

--- a/projects/rat.html
+++ b/projects/rat.html
@@ -31,6 +31,8 @@
 
   <a href="#main" class="skip-link">Skip to main content</a>
 
+  <span class="visually-hidden" role="status" data-copy-status></span>
+
   <header class="navbar">
     <a href="../index.html" class="navbar__logo text-subtitle text-stronger">Emma Shang Hansen</a>
     <button class="navbar__toggle" type="button" aria-expanded="false" aria-controls="navbar-links" aria-label="Open menu">
@@ -38,7 +40,7 @@
     </button>
     <nav id="navbar-links" class="navbar__links" aria-label="Main">
       <a href="../index.html#projects" class="button button--tertiary">Projects</a>
-      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com" aria-live="polite">
+      <button type="button" class="button button--primary" data-copy-email="emmashanghansen@gmail.com">
         <span class="button__labels">
           <span>Copy email</span>
           <span aria-hidden="true">Email copied</span>
@@ -129,9 +131,9 @@
       </button>
     </div>
 
-    <div class="project-footer">
+    <nav class="project-footer" aria-label="Case studies">
       <a href="medication.html" class="button button--secondary project-footer__previous" aria-label="Previous project: Safer medication administration"><svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-left"/></svg><span>Previous project</span></a>
-    </div>
+    </nav>
 
   </div>
   </main>

--- a/projects/rat.html
+++ b/projects/rat.html
@@ -60,24 +60,24 @@
       <div class="project-hero__image">
         <img src="../images/projects/rat/hero.webp" width="2130" height="1200" alt="The game&#39;s title card: &quot;Rat with a Postman Hat&quot; in orange lettering under a blue postman cap, above a wooden sign reading &quot;Best Narrative&quot;, on a dark teal brick wall">
       </div>
-      <ul class="project-hero__details-grid" role="list">
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Role</p>
-          <p class="text-body">Storyteller<br>Musician<br>Potato</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Team</p>
-          <p class="text-body">2 designers<br>1 developer</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">My contribution</p>
-          <p class="text-body">Dialogue, World building, Level design, Soundtracks, Game UI</p>
-        </li>
-        <li class="project-hero__detail">
-          <p class="text-body text-subtle">Award</p>
-          <p class="text-body">Best Narrative – Norwegian Game Awards 2024</p>
-        </li>
-      </ul>
+      <dl class="project-hero__details-grid">
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Role</dt>
+          <dd class="text-body">Storyteller<br>Musician<br>Potato</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Team</dt>
+          <dd class="text-body">2 designers<br>1 developer</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">My contribution</dt>
+          <dd class="text-body">Dialogue, World building, Level design, Soundtracks, Game UI</dd>
+        </div>
+        <div class="project-hero__detail">
+          <dt class="text-body text-subtle">Award</dt>
+          <dd class="text-body">Best Narrative – Norwegian Game Awards 2024</dd>
+        </div>
+      </dl>
     </section>
 
     <!-- Introduction -->
@@ -126,9 +126,9 @@
     </section>
 
     <div class="scroll-top-slot">
-      <button type="button" class="button button--primary button--no-dock scroll-top" aria-label="Back to top" data-scroll-top>
+      <a href="#main" class="button button--primary button--no-dock scroll-top" aria-label="Back to top">
         <svg class="icon" aria-hidden="true"><use href="../images/icons/sprite.svg#icon-arrow-up"/></svg>
-      </button>
+      </a>
     </div>
 
     <nav class="project-footer" aria-label="Case studies">


### PR DESCRIPTION
The homepage went h1 straight to h3: the four project cards were h3 with
no h2 above them, and the section pointed aria-labelledby at a
"projects-heading" id that no longer exists, leaving the landmark
unnamed. Cards are now h2 and the section names itself with aria-label.

Captioned images were a div wrapping an img and a p. That pairing is
what figure and figcaption are for, so all twenty become figures, the
class stays put and nothing about the rendering changes. Same reasoning
for the previous/next block at the foot of each case study: it is
navigation between case studies, so it is a nav with a label rather than
a bare div.

Two smaller fixes alongside: the copy-email status region main.js
announces through only ever existed on the homepage, so the five case
studies fell back to an aria-live on the button itself, the approach the
code comment there explicitly rejects. The region now sits beside the
skip link on all six pages and the aria-live attributes are gone. And
nikita.html had two empty sections rendering as blank padded space.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ScTEGuG4vfjq6naPuJBdkj